### PR TITLE
/!\ dataclasses need python version >=3.6 <3.7 to be installed

### DIFF
--- a/minotoring/Dockerfile
+++ b/minotoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 RUN mkdir /code
 WORKDIR /code

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,8 +124,8 @@ version = "0.34.2"
 test = ["pytest (>=3.0.0)", "pytest-cov"]
 
 [metadata]
-content-hash = "786bd33a6aae419b2b86d9999ec48028cc88695f277b00125ffe653323b36efa"
-python-versions = "^3.6.1"
+content-hash = "604f662358332e19b25b0974bd6ea15f96eb6c8dea8d0e8c6b932e93a5df791b"
+python-versions = "^3.7"
 
 [metadata.files]
 certifi = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Easy to use ML and plug and play monitoring tool."
 authors = ["Boris Ghidaglia <borisghidaglia@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.7"
 requests = "^2.23.0"
 numpy = "^1.18.1"
 pandas = "^1.0.1"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         "tornado==6.0.4",
     ],


### PR DESCRIPTION
Solution : switching python version of the project to 3.7 where dataclasses are part of the default packages (no need to install them)